### PR TITLE
Criado o campo ``_normalized_title``

### DIFF
--- a/opac/catalog/mongomodels.py
+++ b/opac/catalog/mongomodels.py
@@ -143,6 +143,7 @@ class Article(Document):
         for author in self.contrib_group['author']:
             yield author
 
+
 def list_journals(criteria=None, mongomanager_lib=MongoManager):
     """
     Lists all journals present in a collection
@@ -158,7 +159,8 @@ def list_journals(criteria=None, mongomanager_lib=MongoManager):
     if not isinstance(criteria, dict):
         raise ValueError('criteria must be dict')
 
-    for result in mm.find(criteria).sort('title', direction=pymongo.ASCENDING):
+    for result in mm.find(criteria).sort('_normalized_title',
+        direction=pymongo.ASCENDING):
         yield Journal(**result)
 
 

--- a/opac/catalog/test/test_mongo.py
+++ b/opac/catalog/test/test_mongo.py
@@ -531,7 +531,7 @@ class JournalModelTest(TestCase, MockerTestCase):
         mock_mongomanager.find({})
         self.mocker.result(mock_mongomanager)
 
-        mock_mongomanager.sort('title', direction=pymongo.ASCENDING)
+        mock_mongomanager.sort('_normalized_title', direction=pymongo.ASCENDING)
         self.mocker.result([{'title': 'Micronucleated lymphocytes in parents of lalala children'}])
 
         self.mocker.replay()
@@ -577,7 +577,7 @@ class JournalModelTest(TestCase, MockerTestCase):
         mock_mongomanager.find({'study_areas': 'Spam'})
         self.mocker.result(mock_mongomanager)
 
-        mock_mongomanager.sort('title', direction=pymongo.ASCENDING)
+        mock_mongomanager.sort('_normalized_title', direction=pymongo.ASCENDING)
         self.mocker.result([{'title': 'Micronucleated lymphocytes in parents of lalala children'}])
         self.mocker.count(3)
 

--- a/opac/catalog/test/test_templatetags.py
+++ b/opac/catalog/test/test_templatetags.py
@@ -25,7 +25,7 @@ class JournalTemplateTagTest(TestCase, MockerTestCase):
         mock_mongomanager.find({})
         self.mocker.result(mock_mongomanager)
 
-        mock_mongomanager.sort('title', direction=pymongo.ASCENDING)
+        mock_mongomanager.sort('_normalized_title', direction=pymongo.ASCENDING)
         self.mocker.result([{'title': 'Micronucleated'}])
 
         self.mocker.replay()
@@ -51,7 +51,7 @@ class JournalTemplateTagTest(TestCase, MockerTestCase):
         mock_mongomanager.find({'study_areas': 'Zap'})
         self.mocker.result(mock_mongomanager)
 
-        mock_mongomanager.sort('title', direction=pymongo.ASCENDING)
+        mock_mongomanager.sort('_normalized_title', direction=pymongo.ASCENDING)
         self.mocker.result([{'title': 'Micronucleated'}])
         self.mocker.count(1)
 

--- a/opac/utils/sync/pipes.py
+++ b/opac/utils/sync/pipes.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import abc
 import re
+from unicodedata import normalize
 
 from django.conf import settings
 
@@ -212,6 +213,27 @@ class PCleanup(Pipe):
     def transform(self, data):
         if 'is_trashed' in data:
             del(data['is_trashed'])
+
+        return data
+
+
+def pnormalizejournaltitle_precondition(data):
+    """
+    Asserts that:
+
+    * ``title`` exists
+    """
+    if 'title' not in data:
+        raise UnmetPrecondition('missing item "title"')
+
+
+class PNormalizeJournalTitle(Pipe):
+
+    @precondition(pnormalizejournaltitle_precondition)
+    def transform(self, data):
+        ascii_title = normalize('NFKD', data['title']).encode('ASCII', 'ignore')
+
+        data['_normalized_title'] = ascii_title.decode('ASCII').upper()
 
         return data
 

--- a/opac/utils/tasks.py
+++ b/opac/utils/tasks.py
@@ -10,6 +10,7 @@ def full_sync():
     ppl = pipes.Pipeline(pipes.PIssue,
                          pipes.PMission,
                          pipes.PSection,
+                         pipes.PNormalizeJournalTitle,
                          pipes.PCleanup)
 
     data = scielo_api.get_all_journals('saude-publica')


### PR DESCRIPTION
fixes #33

Foi criado um _pipe_ chamado **PNormalizeJournalTitle** que troca caracteres acentuados por seu respectivo não acentuado, por meio de normalização [NFKD](http://en.wikipedia.org/wiki/Unicode_equivalence). Caracteres sem o equivalente em ASCII serão suprimidos. 

O processo ainda normaliza a caixa em caixa alta.
