### PR TITLE
Refatoração de testes de unidade 

### DIFF
--- a/opac/catalog/test/modelfactories.py
+++ b/opac/catalog/test/modelfactories.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import factory
+
+from catalog import mongomodels
+
+
+class JournalFactory(factory.Factory):
+    FACTORY_FOR = mongomodels.Journal
+
+    editor_address = u'Viale Regina Elena 299'
+    copyrighter = u'Istituto Superiore di Sanità'
+    editor_address_city = u'Rome'
+    editor_address_state = u'Rome'
+    creator = u'/api/v1/users/1/'
+    ctrl_vocabulary = u'nd'
+    national_code = None
+    updated = u'2012-11-08T10:35:00.448421'
+    frequency = u'Q'
+    url_journal = None
+    short_title = u'Ann. Ist. Super. Sanità'
+    previous_ahead_documents = 0
+    final_num = ''
+    logo = None
+    publisher_country = u'IT'
+    publisher_name = u'Istituto Superiore di Sanità'
+    eletronic_issn = ''
+    issues = [
+        {
+            u'data':
+            {
+                u'volume': u'45',
+                u'is_marked_up': False,
+                u'updated': u'2012-11-08T10:35:37.193612',
+                u'resource_uri': u'/api/v1/issues/1/',
+                u'total_documents': 17,
+                u'created': u'2010-04-01T01:01:01',
+                u'ctrl_vocabulary': u'nd',
+                u'suppl_volume': None,
+                u'cover': None,
+                u'number': u'4',
+                u'publication_end_month': 12,
+                u'editorial_standard': u'vancouv',
+                u'order': 4,
+                u'publication_year': 2009,
+                u'is_press_release': False,
+                u'suppl_number': None,
+                u'label': u'45 (4)',
+                u'sections': [
+                    {
+                        u'articles': [u'AISS-JHjashA'],
+                        u'id': 514
+                    }
+                ],
+                u'id': 1,
+                u'is_trashed': False,
+                u'publication_start_month': 10
+            },
+            u'id': 1
+        }
+    ]
+    url_online_submission = None
+    init_vol = u'1'
+    subject_descriptors = u'public health'
+    twitter_user = u'redescielo'
+    title = u"Annali dell'Istituto Superiore di Sanit\xe0"
+    pub_status_history = [
+        {u'date': u'2010-04-01T00:00:00', u'status': u'current'}
+    ]
+    id = 1
+    final_year = None
+    editorial_standard = u'vancouv'
+    languages = [u'en', u'it']
+    scielo_issn = u'print'
+    collections = u'/api/v1/collections/1/'
+    index_coverage = u'chemabs\nembase\nmedline\npascal\nzoological records'
+    current_ahead_documents = 0
+    init_year = u'1965'
+    sections = [
+        {
+            u'data': {
+                u'titles': {u'en': u'WHO Publications'},
+                u'id': 514,
+                u'resource_uri': u'/api/v1/sections/514/'
+            },
+            u'id': 514
+        }
+    ]
+    is_indexed_aehci = False
+    use_license = {
+        u'reference_url': None,
+        u'license_code': '',
+        u'id': 1,
+        u'resource_uri': u'/api/v1/uselicenses/1/',
+        u'disclaimer': ''
+    }
+    other_titles = []
+    secs_code = ''
+    editor_address_country = u'Italy'
+    acronym = u'AISS'
+    publisher_state = ''
+    is_indexed_scie = False
+    sponsors = [1]
+    abstract_keyword_languages = None
+    editor_name = u'Istituto Superiore di Sanità'
+    other_previous_title = ''
+    study_areas = [u'Agricultural Sciences']
+    medline_code = None
+    init_num = u'1'
+    publication_city = u'Roma'
+    pub_level = u'CT'
+    is_indexed_ssci = False
+    missions = {
+        u'en': u'To disseminate information on researches in public health'
+    }
+    editor_email = u'annali@iss.it'
+    created = u'2010-04-09T00:00:00'
+    medline_title = None
+    final_vol = ''
+    cover = None
+    editor_phone2 = u'0039 06 4990 2253'
+    editor_phone1 = u'0039 06 4990 2945'
+    print_issn = u'0021-2571'
+    editor_address_zip = u'00161'
+    contact = None
+    pub_status = u'current'
+    pub_status_reason = ''
+    title_iso = u'Ann. Ist. Super. Sanità'
+    notes = ''
+    resource_uri = u'/api/v1/journals/1/'

--- a/opac/catalog/test/test_mongo.py
+++ b/opac/catalog/test/test_mongo.py
@@ -447,33 +447,15 @@ class JournalModelTest(TestCase, MockerTestCase):
         self.assertEqual(journal.id, 1)
 
     def test_address(self):
-        from catalog.mongomodels import Journal
+        from .modelfactories import JournalFactory
 
-        mock_objects = self.mocker.mock()
-
-        address_data = {
-            "editor_address": "Viale Regina Elena 299",
-            "editor_address_city": "Rome",
-            "editor_address_country": "Italy",
-            "editor_address_state": "Rome",
-            }
-
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(address_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build()
         address = journal.address
 
         self.assertEqual(address, "Viale Regina Elena 299, Rome, Rome, Italy")
 
     def test_address_with_missing_data(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+        from .modelfactories import JournalFactory
 
         address_data = {
             "editor_address": "",
@@ -482,123 +464,79 @@ class JournalModelTest(TestCase, MockerTestCase):
             "editor_address_state": "",
             }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(address_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**address_data)
         address = journal.address
 
         self.assertEqual(address, None)
 
     def test_phones_with_many_entries(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+        from .modelfactories import JournalFactory
 
         phone_data = {
             "editor_phone1": "0039 06 4990 2945",
             "editor_phone2": "0039 06 4990 2253",
             }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(phone_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**phone_data)
         phones = journal.phones
 
         self.assertEqual(phones, ['0039 06 4990 2945', '0039 06 4990 2253'])
 
     def test_phones_with_one_entry(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+        from .modelfactories import JournalFactory
 
         phone_data = {
+            "editor_phone1": "",
             "editor_phone2": "0039 06 4990 2253",
             }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(phone_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**phone_data)
         phones = journal.phones
 
         self.assertEqual(phones, ['0039 06 4990 2253'])
 
     def test_phones_with_zero_entries(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+        from .modelfactories import JournalFactory
 
         phone_data = {
             "title": "AAA",
+            "editor_phone1": "",
+            "editor_phone2": "",
         }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(phone_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**phone_data)
         phones = journal.phones
 
         self.assertEqual(phones, [])
 
     def test_phones_with_missing_data(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+        from .modelfactories import JournalFactory
 
         phone_data = {
+            "editor_phone1": "",
             "editor_phone2": "",
             }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(phone_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**phone_data)
         phones = journal.phones
 
         self.assertEqual(phones, [])
 
     def test_phones_with_none_value(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+        from .modelfactories import JournalFactory
 
         phone_data = {
             "editor_phone1": None,
+            "editor_phone2": "",
             }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(phone_data)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**phone_data)
         phones = journal.phones
 
         self.assertEqual(phones, [])
 
-    def test_scielo_issn(self):
-        from catalog.mongomodels import Journal
-
-        mock_objects = self.mocker.mock()
+    def test_scielo_issn_print_version(self):
+        from .modelfactories import JournalFactory
 
         print_issn = {
             "scielo_issn": "print",
@@ -606,28 +544,21 @@ class JournalModelTest(TestCase, MockerTestCase):
             "eletronic_issn": "XXXX-XXXX"
             }
 
+        journal = JournalFactory.build(**print_issn)
+        issn = journal.issn
+
+        self.assertEqual(issn, 'AAAA-AAAA')
+
+    def test_scielo_issn_electronic_version(self):
+        from .modelfactories import JournalFactory
+
         electronic_issn = {
             "scielo_issn": "electronic",
             "print_issn": "AAAA-AAAA",
             "eletronic_issn": "XXXX-XXXX"
             }
 
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(print_issn)
-
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(electronic_issn)
-
-        self.mocker.replay()
-
-        Journal.objects = mock_objects
-
-        journal = Journal.get_journal(journal_id='foo')
-        issn = journal.issn
-
-        self.assertEqual(issn, 'AAAA-AAAA')
-
-        journal = Journal.get_journal(journal_id='foo')
+        journal = JournalFactory.build(**electronic_issn)
         issn = journal.issn
 
         self.assertEqual(issn, 'XXXX-XXXX')
@@ -719,19 +650,15 @@ class JournalModelTest(TestCase, MockerTestCase):
         self.assertEqual(j.issues_count, 0)
 
     def test_tweets_valid_user(self):
-        from catalog.mongomodels import Journal
-        from twitter import TwitterError
+        from .modelfactories import JournalFactory
+        from catalog import mongomodels
 
-        mock_objects = self.mocker.mock()
         mock_twitter = self.mocker.mock()
         mock_tweet = self.mocker.mock()
 
         twitter_user = {
             "twitter_user": "redescielo"
             }
-
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(twitter_user)
 
         mock_twitter.GetUserTimeline(ANY, page=0, count=3)
         self.mocker.result([mock_tweet])
@@ -745,9 +672,10 @@ class JournalModelTest(TestCase, MockerTestCase):
         self.mocker.replay()
 
         # Testing valid twitter user
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
-        Journal._twitter_api = mock_twitter  # monkeypatch
+        journal = JournalFactory.build(**twitter_user)
+
+        # monkeypatch a class attribute
+        mongomodels.Journal._twitter_api = mock_twitter
 
         tweets = journal.tweets
 
@@ -757,18 +685,15 @@ class JournalModelTest(TestCase, MockerTestCase):
                         u'Mon Feb 04 13:41:19 +0000 2013')
 
     def test_tweets_invalid_user(self):
-        from catalog.mongomodels import Journal
+        from .modelfactories import JournalFactory
+        from catalog import mongomodels
         from twitter import TwitterError
 
-        mock_objects = self.mocker.mock()
         mock_twitter = self.mocker.mock()
 
         twitter_user = {
             "twitter_user": "invalid_user"
             }
-
-        mock_objects.find_one({'acronym': 'foo'})
-        self.mocker.result(twitter_user)
 
         mock_twitter.GetUserTimeline(ANY, page=0, count=3)
         self.mocker.throw(TwitterError)
@@ -776,9 +701,10 @@ class JournalModelTest(TestCase, MockerTestCase):
         self.mocker.replay()
 
         # Testing valid twitter user
-        Journal.objects = mock_objects
-        journal = Journal.get_journal(journal_id='foo')
-        Journal._twitter_api = mock_twitter  # monkeypatch
+        journal = JournalFactory.build(**twitter_user)
+
+        # monkeypatch a class attribute
+        mongomodels.Journal._twitter_api = mock_twitter
 
         # Testing invalid twitter user
         tweets = journal.tweets

--- a/opac/catalog/test/test_mongo.py
+++ b/opac/catalog/test/test_mongo.py
@@ -10,6 +10,8 @@ from mocker import (
     KWARGS,
 )
 
+from catalog.mongomodels import Journal
+
 
 class MongoManagerTest(TestCase, MockerTestCase):
 
@@ -303,8 +305,20 @@ class ArticleModelTest(TestCase, MockerTestCase):
 
 class JournalModelTest(TestCase, MockerTestCase):
 
+    def setUp(self):
+        """
+        Backup the original ``objects`` object ref.
+        """
+        self._original_objects = Journal.objects
+
+    def tearDown(self):
+        """
+        Restore to the original ``objects`` object ref.
+        """
+        Journal.objects = self._original_objects
+
     def _makeOne(self, *args, **kwargs):
-        from catalog.mongomodels import Journal
+
         return Journal(*args, **kwargs)
 
     def test_simple_attr_access(self):
@@ -375,8 +389,6 @@ class JournalModelTest(TestCase, MockerTestCase):
         self.assertTrue(False)
 
     def test_get_journal_passing_journal_id(self):
-        from catalog.mongomodels import Journal
-
         mock_objects = self.mocker.mock()
 
         journal_microdata = {

--- a/opac/catalog/test/test_pages.py
+++ b/opac/catalog/test/test_pages.py
@@ -1,0 +1,27 @@
+from django_webtest import WebTest
+from django.core.urlresolvers import reverse
+
+
+class AjxListJournalTweets(WebTest):
+
+    def test_returns_400_code_when_request_isnot_ajax(self):
+        from .modelfactories import JournalFactory
+        j = JournalFactory.build(twitter_user='redescielo')
+
+        response = self.app.get(
+            reverse('catalog.ajx_list_journal_tweets',
+                kwargs={'journal_id': j.acronym}),
+            status=400
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_returns_400_code_when_the_journal_id_doesnot_exist(self):
+        response = self.app.get(
+            reverse('catalog.ajx_list_journal_tweets',
+                kwargs={'journal_id': 'invalid'}),
+            status=400,
+            headers={'x-requested-with': 'XMLHttpRequest'},
+        )
+
+        self.assertEqual(response.status_code, 400)

--- a/opac/catalog/views.py
+++ b/opac/catalog/views.py
@@ -49,7 +49,10 @@ def ajx_list_journal_tweets(request, journal_id):
     if not request.is_ajax():
         return HttpResponse(status=400)
 
-    journal = mongomodels.Journal.get_journal(journal_id=journal_id)
+    try:
+        journal = mongomodels.Journal.get_journal(journal_id=journal_id)
+    except ValueError:
+        return HttpResponse(status=400)
 
     tweets = journal.tweets
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,1 +1,5 @@
 mocker
+factory_boy
+django_factory_boy
+webtest==1.4.0
+django-webtest==1.5.6


### PR DESCRIPTION
- Alguns testes foram divididos em múltiplos casos de teste, para garantir o isolamento e manutenção.
- Criada factory de instâncias de Journal, para facilitar os testes de métodos que não envolvem persistência.

fixes #41 
