### PR TITLE
Corrigindo bug em tweets

### DIFF
--- a/opac/catalog/mongomodels.py
+++ b/opac/catalog/mongomodels.py
@@ -227,6 +227,8 @@ class Journal(Document):
         {'attr': 'acronym', 'unique': True}
     ])
 
+    _twitter_api = twitter.Api()
+
     @classmethod
     def get_journal(cls, journal_id):
         """

--- a/opac/catalog/test/test_mongo.py
+++ b/opac/catalog/test/test_mongo.py
@@ -680,6 +680,13 @@ class JournalModelTest(TestCase, MockerTestCase):
         j = self._makeOne(**issues_data)
         self.assertEqual(j.issues_count, 0)
 
+    def test_journal_twitter_api_class_atribute(self):
+        from catalog.mongomodels import Journal
+
+        self.assertEqual(
+            hasattr(Journal, '_twitter_api'),
+            True)
+
     def test_tweets_valid_user(self):
         from .modelfactories import JournalFactory
         from catalog import mongomodels


### PR DESCRIPTION
Atributo _twitter_api foi removido da classe mongomodels.Journal por engano.
