### PR TITLE
Correção de bug na coleta de metadados de periódicos no processo de montagem do catálogo

### DIFF
--- a/opac/utils/sync/datacollector.py
+++ b/opac/utils/sync/datacollector.py
@@ -87,11 +87,12 @@ class SciELOManagerAPI(object):
         offset = 0
         limit = ITEMS_PER_REQUEST
 
-        qry_params = {'offset': offset, 'limit': limit}
+        qry_params = {'limit': limit}
         if collection:
             qry_params.update({'collection': collection})
 
         while True:
+            qry_params.update({'offset': offset})
             doc = self.fetch_data(endpoint, **qry_params)
 
             for obj in doc['objects']:

--- a/opac/utils/sync/dataloader.py
+++ b/opac/utils/sync/dataloader.py
@@ -2,12 +2,12 @@ import pymongo
 
 from django.conf import settings
 
-from catalog.mongomodels import MongoConnector
+from catalog import mongomodels
 
 
 class Marreta(object):
 
-    def __init__(self, mongoconn_lib=MongoConnector,
+    def __init__(self, mongoconn_lib=mongomodels.MongoConnector,
                        pymongo_lib=pymongo,
                        settings=settings):
 
@@ -32,6 +32,7 @@ class Marreta(object):
         self._mongoconn.db.drop_collection(collection)
 
         col = self._mongoconn.db[collection]
+        mongomodels.ensure_all_indexes()
 
         for data in new_data:
             col.insert(data, w=1)


### PR DESCRIPTION
Também foi resolvido um problema que impedia a criação dos índices no MongoDB logo após o _build_ do catálogo.
